### PR TITLE
Bug/mocked window issue

### DIFF
--- a/spec/window.js
+++ b/spec/window.js
@@ -1,0 +1,7 @@
+describe("window", function() {
+    var storage = require('../storage');
+
+    it("does not mock window as object literal", function() {
+        expect(typeof global.window).not.toEqual('object');
+    });
+});

--- a/storage.js
+++ b/storage.js
@@ -1,16 +1,15 @@
 /**
  * Jenkins client-side storage.
  */
+var local;
 
-if (global.window === undefined) {
-    global.window = {};
-}
-if (!global.window.localStorage) {
+if (global.window && global.window.localStorage) {
+    local = global.window.localStorage;
+} else {
     console.warn('No window.localStorage. Creating a mock in-memory localStorage, assuming this is running in a test environment.');
-    global.window.localStorage = require('localstorage-memory');
+    local = require('localstorage-memory');
 }
 
-var local = global.window.localStorage;
 exports.local = local;
 
 var TYPE_OBJECT = '_$_object:';


### PR DESCRIPTION
Ran into an issue where mocking `global.window` can interfere with other libraries. Many libs check for the presence of `window` and if it exists, they assume that other properties like `location` will be available too. These libraries should probably do more rigorous null checking but we can't control that unfortunately.

Concrete example:
- While trying to use the `nock` library in some core-js tests, the `sinon` library was throwing some NPE's from here: https://github.com/sinonjs/sinon/blob/v1.17.6/lib/sinon/util/fake_server.js#L38

@tfennelly 